### PR TITLE
adds MitreID and MitreURL methods to MitreMatrix type.

### DIFF
--- a/mitre_matrix.go
+++ b/mitre_matrix.go
@@ -36,3 +36,25 @@ func (m *MitreMatrix) Tactics() []*MitreTactic {
 func (m *MitreMatrix) SetTactics(tactics []*MitreTactic) {
 	m.tactics = tactics
 }
+
+// MitreID returns the external mitre id for this matrix
+func (m *MitreMatrix) MitreID() string {
+	for _, ref := range m.ExternalReferences {
+		if ref.IsMitre() {
+			return ref.ExternalID
+		}
+	}
+
+	return ""
+}
+
+// MitreURL returns the external mitre url for this matrix
+func (m *MitreMatrix) MitreURL() string {
+	for _, ref := range m.ExternalReferences {
+		if ref.IsMitre() {
+			return ref.URL
+		}
+	}
+
+	return ""
+}

--- a/mitre_tactic.go
+++ b/mitre_tactic.go
@@ -56,7 +56,7 @@ func (m *MitreTactic) MitreID() string {
 	return ""
 }
 
-// MitreURL returns the external mitre url for this attack pattern
+// MitreURL returns the external mitre url for this tactic
 func (m *MitreTactic) MitreURL() string {
 	for _, ref := range m.ExternalReferences {
 		if ref.IsMitre() {

--- a/stix_test.go
+++ b/stix_test.go
@@ -419,6 +419,8 @@ func TestFromReaderMitreMobileSpec_2_1(t *testing.T) {
 		matrices := c.MitreMatrices()
 		require.Len(t, matrices, 2)
 		for _, m := range matrices {
+			require.NotEmpty(t, m.MitreID())
+			require.NotEmpty(t, m.MitreURL())
 			matrix := c.MitreMatrix(m.ID)
 			assert.NotEmpty(t, matrix, "could not find %s", m.ID)
 			assert.Equal(t, m, matrix)


### PR DESCRIPTION
### Background

A mitre matrix can have a url and an external mitre ID. 

### Changes

* adds helper methods for retrieving the external mitre id/url for a matrix
